### PR TITLE
Use Ruby 3.2.2-alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.0-alpine
+FROM ruby:3.2.2-alpine
 
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The Bundler Audit GitHub Action is currently failing in CI.

@laicuRoot has submitted a PR to the maintainer that fixes this by updating the `Dockerfile` to use the latest available version of Ruby.

This commit applies the fix for us to use the action while waiting for the upstream changes..

Ref:
- https://github.com/andrewmcodes/bundler-audit-action/pull/6
