### PR TITLE
Use Ruby 3.3.0 in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-alpine
+FROM ruby:3.3.0-alpine
 
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This commit updates `Dockerfile` to use Ruby 3.3.0 which is now available.

Ref:
- https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
- https://hub.docker.com/layers/library/ruby/3.3.0-alpine/images/sha256-551360a63fecdab23732f6350c12796c32982e3d48d2e27ae348044f910ce8fa?context=explore
